### PR TITLE
save UTF8 icons

### DIFF
--- a/src/Resources/contao/dca/tl_cowegis_icon.php
+++ b/src/Resources/contao/dca/tl_cowegis_icon.php
@@ -431,7 +431,7 @@ $GLOBALS['TL_DCA']['tl_cowegis_icon'] = [
         'content'           => [
             'exclude'   => true,
             'inputType' => 'text',
-            'eval'      => ['tl_class' => 'w50'],
+            'eval'      => ['tl_class' => 'w50', 'decodeEntities' => true,],
             'sql'       => 'varchar(64) NOT NULL default \'\'',
         ],
     ],


### PR DESCRIPTION
we can save UTF8 icons like 🌩 `&#127785;`

![image](https://github.com/user-attachments/assets/ff21177b-69db-4139-b015-ff7c1e5ad3f5)
